### PR TITLE
Add openssh to the packages in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM archlinux:latest
 LABEL org.opencontainers.image.description="A work-in-progress, easy to use, set up and configure Arch Linux derivative"
 
 RUN  pacman -Syu --noconfirm
-RUN  pacman -S --needed --noconfirm pacman-contrib base-devel git wget
+RUN  pacman -S --needed --noconfirm pacman-contrib base-devel git wget openssh
 
 RUN  useradd -u 901 temp-user
 RUN  mkdir /tmp/crystal-keyring


### PR DESCRIPTION
Signed-off-by: Oro <93224879+orowith2os@users.noreply.github.com>

Mainly needed for `git`'s `ssh` functionality. Not included in base-devel.